### PR TITLE
docs: fix patch_self link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,4 @@ from you, my email and X DMs are open.
 * LightningMods for explaining libc memory allocation constraints
 
 [releases]: https://github.com/0xcaff/extern_traces/releases
-[patch_self.py]: https://github.com/0xcaff/extern_traces/blob/main/packages/trace_plugin/patch_self.py
+[patch_self.py]: https://github.com/0xcaff/extern_traces/blob/main/packages/extern_traces_plugin/patch_self.py


### PR DESCRIPTION
## Summary
- fix the README link to patch_self.py

## Testing
- `cargo test` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_68b8cab55e54832faad0a904f0c04fde