### PR TITLE
Remove CUSA00810 references from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,6 @@ the ps4.
      ; configuration detailed below in "patching targets" section
      [CUSA08010]
      original_tls_size = 0
-     
-     [CUSA00810]
-     original_tls_size = 528
      ```
 
 2. install trace viewer
@@ -51,7 +48,7 @@ update the `/data/extern_traces.ini` with a section for the newly patched title
 including the size of the original tls segment.
 
 ```
-[CUSA00810]
+[TITLE_ID]
 original_tls_size = 528
 ```
 


### PR DESCRIPTION
## Summary
- remove CUSA00810 from example configuration in README
- replace patching example with generic TITLE_ID placeholder

## Testing
- `cargo test` *(fails: unsuccessful tunnel)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8cabda7c0832f93446be37fc84c12